### PR TITLE
Fix eslint error on extending dir

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: [`./eslint`],
+  extends: [`./eslint/index.js`],
 };

--- a/eslint/react.js
+++ b/eslint/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: [`standard-jsx`, `standard-react`, `prettier/react`, `.`],
+  extends: [`standard-jsx`, `standard-react`, `prettier/react`, `./index.js`],
   plugins: [`react-hooks`, `react`],
   rules: {
     "react-hooks/rules-of-hooks": `error`,


### PR DESCRIPTION
In a recent eslint update, extending a directory (e.g. `extends: './eslint'` instead of `./eslint/index.js`) stopped working.